### PR TITLE
Handle index error in paragraphs

### DIFF
--- a/pdf2docx/layout/Sections.py
+++ b/pdf2docx/layout/Sections.py
@@ -66,7 +66,11 @@ class Sections(BaseCollection):
             # NOTE: the after space doesn't work if last paragraph is 
             # image only (without any text). In this case, set after
             # space for the section break.
-            p = doc.paragraphs[-2] # -1 is the section break
+            try:
+                p = doc.paragraphs[-2] # -1 is the section break
+            except IndexError:
+                p = doc.paragraphs[-1]
+
             if not p.text.strip() and 'graphicData' in p._p.xml:
                 p = doc.paragraphs[-1]
             pf = p.paragraph_format


### PR DESCRIPTION
Some documents can't be processed page by page due to an index error. As a result pages are blank.
This small fix handles the exception are pages are being extracted as expected. I'm not sure, though, if it's best to skip the section (`continue`) or take last paragraph instead of the one before it (what I did).
If you prefer the first option - let me know please.