### PR TITLE
fix gui

### DIFF
--- a/pdf2docx/gui/MainFrame.py
+++ b/pdf2docx/gui/MainFrame.py
@@ -27,11 +27,11 @@ class MainFrame(Frame):
         self.program_use_label.grid(row=0, column=0, columnspan=2, padx=120, pady=50)
 
         # PDF file entry
-        self.file_path_pdf_entry = Entry(self, border=5, width=55)
+        self.file_path_pdf_entry = Entry(self, border=5)
         self.file_path_pdf_entry.grid(row=1, column=0, sticky='w', ipady=4, padx=10)
 
         # Docx file entry
-        self.file_path_docx_entry = Entry(self, border=5, width=55)
+        self.file_path_docx_entry = Entry(self, border=5)
         self.file_path_docx_entry.grid(row=2, column=0, sticky='w', ipady=4, padx=10, pady=75)
 
         # Select PDF files Button


### PR DESCRIPTION
The unit of width option in Tkinter Entry widget is text units but not pixels, so in some environment, the input Entry may overflow the window. Just remove `width` to make it self-adaption.

before:

<img width="500" alt="before" src="https://github.com/dothinking/pdf2docx/assets/1646590/fdcf0cf1-35a2-4a30-9461-8b0a97f43ca2">

after:

<img width="500" alt="after" src="https://github.com/dothinking/pdf2docx/assets/1646590/1171f4d0-44a9-4691-bf27-7dabc3d13745">

