### PR TITLE
Attempting sphinxcontrib.apidoc to generate low-level API docs.

### DIFF
--- a/doc/api/modules.rst
+++ b/doc/api/modules.rst
@@ -1,5 +1,5 @@
-API Documentation
-=================
+pdf2docx
+========
 
 .. toctree::
    :maxdepth: 4

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,8 +40,13 @@ release = get_version('../version.txt')
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc'
+    'sphinxcontrib.apidoc'
 ]
+
+apidoc_module_dir = '../pdf2docx'
+apidoc_output_dir = 'api'
+apidoc_excluded_paths = []
+apidoc_separate_modules = True
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,7 +14,7 @@ generate docx file with ``python-docx``.
    installation
    quickstart
    techdoc
-   modules
+   api/modules
 
 
 Indices and tables

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,11 +9,17 @@ generate docx file with ``python-docx``.
 
 .. toctree::
    :maxdepth: 2
-   :caption: Contents:
+   :caption: USER GUIDE
 
    installation
    quickstart
    techdoc
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: API DOCUMENTATION
+
    api/modules
 
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,3 +4,4 @@ rst2pdf
 sphinx==5.3.0
 autodoc
 sphinx_rtd_theme
+sphinxcontrib.apidoc


### PR DESCRIPTION
Build command from root folder is:
`sphinx-build -a -b html doc doc/build/html`

But I get `pdf2docx module not found`.

