### PR TITLE
sort lines

### DIFF
--- a/pdf2docx/text/Lines.py
+++ b/pdf2docx/text/Lines.py
@@ -59,6 +59,8 @@ class Lines(ElementCollection):
             to bottom.
         '''
         rows = self.group_by_physical_rows()
+        for row in rows:
+            row.sort_in_reading_order()
 
         # skip if only one row
         num = len(rows)


### PR DESCRIPTION
sometimes the text is out of order, such as:
<img width="963" alt="image" src="https://github.com/user-attachments/assets/9fdbbb2b-6bf6-4aae-89e0-093be7625402">
<img width="1370" alt="image" src="https://github.com/user-attachments/assets/9932a8f3-c4e2-4170-ab96-6abed573b479">
